### PR TITLE
Fix VSCode keyboard shortcuts being intercepted in input field

### DIFF
--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1753,6 +1753,13 @@ import type {
 
     // Handle keyboard navigation in textarea (for autocomplete and submit)
     responseInput?.addEventListener('keydown', (event: KeyboardEvent) => {
+        // Allow VS Code shortcuts (e.g. option+f, cmd+k, ctrl+g) to pass through the input
+        const isVSCodeCommand = event.altKey || event.metaKey || (event.ctrlKey && !event.shiftKey);
+        if (isVSCodeCommand) {
+            // Prevent character insertion, but let the event bubble for VS Code to handle the shortcut
+            event.preventDefault();
+            return;
+        }
 
         // Autocomplete navigation
         if (autocompleteVisible) {


### PR DESCRIPTION
Thank you for this great extension.

This PR  fixed an issue:

The Seamless Agent panel is placed in the right sidebar, and I use the shortcut Option + F to maximize the sidebar.

When the mouse focus is in the Seamless Agent's input field, pressing the shortcut results in the character "f" being typed into the input field.

<img width="195" height="155" alt="image" src="https://github.com/user-attachments/assets/02a15c16-c585-4024-82e0-49df8b28c7b3" />