### PR TITLE
feat: add draggable resize handle for ask_user textarea

### DIFF
--- a/media/main.css
+++ b/media/main.css
@@ -878,6 +878,42 @@ button:disabled {
    Chips Container Styles
    ================================ */
 
+/* ================================
+   Resize Handle Styles
+   ================================ */
+
+.resize-handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 8px;
+    cursor: ns-resize;
+    user-select: none;
+    -webkit-user-select: none;
+    border-radius: 4px 4px 0 0;
+    opacity: 0.5;
+    transition: opacity 0.15s ease, background-color 0.15s ease;
+    margin-top: 4px;
+}
+
+.resize-handle:hover,
+.resize-handle.dragging {
+    opacity: 1;
+    background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.resize-handle-grip {
+    width: 32px;
+    height: 2px;
+    border-radius: 1px;
+    background-color: var(--vscode-descriptionForeground);
+}
+
+.resize-handle:hover .resize-handle-grip,
+.resize-handle.dragging .resize-handle-grip {
+    background-color: var(--vscode-foreground);
+}
+
 /* Input container wraps everything */
 .input-container {
     display: flex;
@@ -969,7 +1005,7 @@ button:disabled {
 .input-area .textarea-wrapper textarea {
     width: 100%;
     min-height: auto !important;
-    max-height: var(--textarea-max-height) !important;
+    max-height: none !important; /* Height controlled dynamically by JS + resize handle */
     height: auto;
     padding: 8px 12px 8px 0;
     border: none !important;

--- a/media/webview.html
+++ b/media/webview.html
@@ -193,6 +193,11 @@
             </div>
           </div>
 
+          <!-- Resize handle for textarea -->
+          <div class="resize-handle" id="resize-handle" title="Drag to resize">
+            <div class="resize-handle-grip"></div>
+          </div>
+
           <!-- Modern input container with chips, attach icon, and textarea -->
           <div class="input-container">
             <!-- Chips bar (hidden when no attachments) -->


### PR DESCRIPTION
## Summary

Adds a draggable resize handle above the textarea in the Agent Console webview, allowing users to expand or shrink the input area by dragging the top edge.

## Changes

- **media/webview.html**: Added a resize handle div above the input container
- **media/main.css**: Styled the resize handle (grip bar, cursor, hover/drag feedback) and removed CSS max-height constraint on textarea (now JS-controlled)
- **src/webview/main.ts**: Implemented drag-to-resize logic with mousedown/mousemove/mouseup tracking

## Behavior

- Drag the handle **up** to expand the textarea, **down** to shrink it (up to 2000px max)
- The auto-resize behavior still works: content growth expands the textarea, but the user-set height acts as a minimum
- **Double-click** the handle to reset to auto-resize behavior
- Height resets when switching between questions
- No visual disruption when the handle is not being used (subtle grip indicator at 50% opacity)