### PR TITLE
fix: render pending list immediately after webview JS is ready

### DIFF
--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -243,6 +243,9 @@ export type FromWebviewMessage = | {
         type: 'saveDraft';
         requestId: string;
         draftText: string
+    }
+    | {
+        type: 'webview-ready'
     };
 
 

--- a/src/webview/webviewProvider.ts
+++ b/src/webview/webviewProvider.ts
@@ -104,13 +104,8 @@ export class AgentInteractionProvider implements vscode.WebviewViewProvider {
             void this._handleWebviewMessage(message);
         }, undefined, []);
 
-        // Always show home view first (which includes pending requests and recent sessions)
-        this._showHome();
-
-        // Update badge count
-        if (this._pendingRequests.size > 0) {
-            this._setBadge(this._pendingRequests.size);
-        }
+        // _showHome() will be called once the webview signals it is ready
+        // (see 'webview-ready' handler in _handleWebviewMessage)
     }
 
     /**
@@ -385,6 +380,10 @@ export class AgentInteractionProvider implements vscode.WebviewViewProvider {
                 break;
             case 'backToHome':
                 // Don't clear _lastOpenedRequestId - keep for sorting
+                this._showHome();
+                break;
+            case 'webview-ready':
+                // Webview JS has finished loading; send initial state now
                 this._showHome();
                 break;
             case 'clearHistory': {


### PR DESCRIPTION
Closes #81

## Root Cause

`resolveWebviewView` is only called once (because `retainContextWhenHidden: true`). It was calling `_showHome()` → `postMessage('showHome')` **synchronously** right after setting `webview.html`, but at that point the webview's JavaScript hadn't finished loading yet. The message was silently dropped by VS Code, leaving the pending list visually empty even though the internal count was correct (badge showed 1).

Navigating to History and back triggered another `_showHome()` call, at which point the webview was already ready — so it worked as a workaround.

## Fix

Introduce a `webview-ready` handshake:

1. **`src/webview/main.ts`** — After all initialization code runs and the `window.addEventListener('message', ...)` listener is registered, the webview immediately posts `{ type: 'webview-ready' }` to the extension host.

2. **`src/webview/webviewProvider.ts`** — `_handleWebviewMessage` handles `'webview-ready'` by calling `_showHome()`, guaranteeing the initial state is delivered only after the webview is ready to receive it. The premature `_showHome()` call in `resolveWebviewView` is removed.

3. **`src/webview/types.ts`** — `{ type: 'webview-ready' }` is added to the `FromWebviewMessage` union type.

## Testing

1. Install/update the extension.
2. Trigger a pending request from an AI agent.
3. Open the extension panel — the pending request should be visible immediately without needing to navigate away and back.