### PR TITLE
fix(ask-user): resolve session-end cleanup, stale selection, and list visibility (#81)

### DIFF
--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -3040,7 +3040,10 @@ import { truncate } from './utils';
         switch (message.type) {
             case 'showQuestion': showQuestion(message.question, message.title, message.requestId, message.options, message.pendingCount, message.requestOrder, message.attachments);
                 break;
-            case 'showList': showList(message.requests, message.selectedRequestId);
+            case 'showList': if (message.requests && message.requests.length > 0) {
+                switchTab('pending');
+            }
+                showList(message.requests, message.selectedRequestId);
                 break;
             case 'updatePendingCount': updatePendingCountBadge(message.count, message.requestOrder);
                 break;

--- a/src/webview/webviewProvider.ts
+++ b/src/webview/webviewProvider.ts
@@ -165,8 +165,8 @@ export class AgentInteractionProvider implements vscode.WebviewViewProvider {
             // Update badge count
             this._setBadge(this._pendingRequests.size);
 
-            // Keep current view if a request is already being viewed
-            if (this._selectedRequestId) {
+            // Keep current view only when selected request is still valid
+            if (this._selectedRequestId && this._pendingRequests.has(this._selectedRequestId)) {
                 // Get the currently selected request and refresh it with updated pending count
                 const currentRequest = this._pendingRequests.get(this._selectedRequestId);
                 if (currentRequest) {
@@ -1036,6 +1036,11 @@ export class AgentInteractionProvider implements vscode.WebviewViewProvider {
 
             pending.resolve(cleanResult);
             this._pendingRequests.delete(requestId);
+
+            // Clear selected request if it was just resolved
+            if (this._selectedRequestId === requestId) {
+                this._selectedRequestId = null;
+            }
 
             // Clear last opened if this was the last opened request
             if (this._lastOpenedRequestId === requestId) {


### PR DESCRIPTION
Closes #81

## Summary

This pull request addresses several UI issues in the `ask_user` request flow where pending requests could remain visible after a session ended, fail to appear until navigating history, or show mismatched counts between the badge and list. These issues were related but surfaced together, so the fixes are consolidated in one PR.

---

## Issue 1 — Stale pending items after session end

### Problem

When a session triggered multiple `ask_user` requests and was then stopped, the UI sometimes continued showing a stale pending item even though the provider had already cancelled every request.

### Cause

On session end:
1. All pending requests were cancelled in the provider.
2. A `clear` message was sent to the webview.
3. `showHome()` was executed, but **did not clear the pending requests DOM list**, leaving stale items in view.

### Fix

The `clear` webview message now explicitly clears the list:

```ts
case 'clear':
    showHome();
    if (pendingRequestsList) {
        clearChildren(pendingRequestsList);
    }
    hideAutocomplete();
    break;
```

This ensures the list is always cleared when the agent session ends.

---

## Issue 2 — Pending list rendered but not visible due to tab state

### Problem

When pending items existed, the list could appear empty if the UI was not currently on the Pending tab. The activity badge would update, but the actual list remained hidden.

### Cause

- The `showList` handler rendered the entries but **did not activate the Pending tab**.
- The provider's pending-request routing could preserve the question panel incorrectly if the selected request was no longer valid.

### Fixes

1. Provider (`webviewProvider.ts`):
   - Add stronger validity checks for `_selectedRequestId`.
   - Clear stale selections so the UI is not blocked by an invalid ID.

2. Webview (`main.ts`):
   - If pending items exist during `showList`, automatically switch to the Pending tab.

---

## Issue 3 — Second and later ask_user requests hidden until navigating history

### Problem

After the first request, subsequent sequential `ask_user` prompts sometimes failed to appear in the UI even though the count badge increased.

### Cause

When a request was resolved, its ID could remain stored in `_selectedRequestId`:

- The provider’s routing prioritized `_selectedRequestId`.
- Since that ID had already been removed from `_pendingRequests`, the lookup failed.
- No UI update (`showQuestion` or `showList`) was sent.

### Fixes

1. In `_resolveRequest()`, clear `_selectedRequestId` when resolving the active request.
2. In `waitForUserResponse()`, only use the "selected request" branch if the ID exists in `_pendingRequests`.

---

## Verification

- Trigger multiple `ask_user` requests → cancel session → list fully clears.  
- Trigger sequential requests → each request appears immediately.  
- Pending tab correctly activates when items are present.  
- All automated checks pass:
  - `npm run check-types` ✔️  
  - `npm test` (37 passed) ✔️  
  - `npm run compile` ✔️  
  - `npm run package:vsce` ✔️  
- Built artifact: `seamless-agent-0.1.24.vsix`

---

## Files Updated

### Provider Logic
- `src/webview/webviewProvider.ts`
  - Added stale-selection cleanup.
  - Added defensive validity checks.
  - Improved routing for pending request visibility.

### Webview Logic
- `src/webview/main.ts`
  - Explicit clearing of pending list on `clear`.
  - Auto-switch to Pending tab on `showList` when items exist.

---

## Why This Approach

- Keeps the behavior minimal and targeted.
- Preserves the intended user experience.
- Ensures the UI remains synchronized with the provider’s state.
- Eliminates stale DOM and hidden pending request issues without altering unrelated flows.
