### PR TITLE
fix: textarea sizing in narrow sidebar

### DIFF
--- a/media/main.css
+++ b/media/main.css
@@ -1100,6 +1100,7 @@ button:disabled {
 .input-area .textarea-wrapper {
     flex: 1;
     position: relative;
+    min-width: 0;
 }
 
 .input-area .textarea-wrapper textarea {

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1096,8 +1096,6 @@ function applyAskUserOptionsTooltipMode(): void {
 
         if (responseInput) {
             responseInput.value = draftResponses.get(requestId) || '';
-            // Initialize textarea height
-            autoResizeTextarea();
         }
 
         // Render option buttons if provided
@@ -1111,6 +1109,9 @@ function applyAskUserOptionsTooltipMode(): void {
         // Show header and form
         requestHeader?.classList.remove('hidden');
         requestForm?.classList.remove('hidden');
+
+        // Resize after the form becomes visible so placeholder wrapping affects scrollHeight correctly.
+        requestAnimationFrame(() => autoResizeTextarea());
 
         // Update attachments display
         updateAttachmentsDisplay();


### PR DESCRIPTION
## Summary

Fixes two textarea issues in the `Your response` input:

- In narrow sidebars, the placeholder could be clipped from the left, leaving only the end of the text visible, and the cursor seems missing
- On first render, the textarea height could differ from the empty state after typing and clearing the input

## Cause

- The textarea wrapper is a flex item. Without `min-width: 0`, it does not shrink properly in a narrow container, which can clip the visible textarea area from the left
- The initial `autoResizeTextarea()` ran before the form became visible, so `scrollHeight` was measured before layout had settled at the final width

## Fix

- Add `min-width: 0` to `.input-area .textarea-wrapper` so the textarea can shrink correctly inside a narrow sidebar
- Move the initial `autoResizeTextarea()` call to run after the form is shown via `requestAnimationFrame`, so the height is measured after layout is complete and matches the wrapped placeholder state

## Screenshots

| Before | After |
| --- | --- |
|<img width="310" height="171" alt="SCR-20260404-rsip" src="https://github.com/user-attachments/assets/25f3d959-b27f-4fbf-8f0f-2d6a3b208402" />|<img width="260" height="179" alt="SCR-20260404-sauf" src="https://github.com/user-attachments/assets/f48946f0-30cb-46f5-98d3-4eceacbf42d6" />|




## Verification

- Narrowed the sidebar and confirmed the placeholder and caret render correctly
- Typed and cleared the input and confirmed the initial height now matches the empty-state height
