### PR TITLE
fix: improve attachment input placement and preview hover

### DIFF
--- a/media/main.css
+++ b/media/main.css
@@ -655,10 +655,19 @@ body[data-ask-user-options-tooltip="native"] .option-btn-tooltip {
     position: relative;
 }
 
+.response-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
 .response-label {
     display: block;
-    margin-bottom: 8px;
+    margin: 0;
     font-weight: 500;
+    min-width: 0;
 }
 
 textarea {
@@ -1075,21 +1084,28 @@ button:disabled {
 
 .attach-btn {
     flex-shrink: 0;
-    width: 32px;
+    width: 28px;
+    height: 28px;
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
     background: transparent;
-    border: none;
+    border: 1px solid transparent;
     cursor: pointer;
     color: var(--vscode-descriptionForeground);
-    padding: 8px 4px;
+    padding: 0;
     border-radius: 4px;
 }
 
 .attach-btn:hover {
     background-color: var(--vscode-toolbar-hoverBackground);
+    border-color: var(--vscode-widget-border, var(--vscode-input-border));
     color: var(--vscode-foreground);
+}
+
+.attach-btn:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
 }
 
 .attach-btn .codicon {
@@ -1109,7 +1125,7 @@ button:disabled {
     max-height: none !important;
     /* Height controlled dynamically by JS + resize handle */
     height: auto;
-    padding: 8px 12px 8px 0;
+    padding: 8px 12px;
     border: none !important;
     background: transparent !important;
     color: var(--vscode-input-foreground);

--- a/media/webview.html
+++ b/media/webview.html
@@ -145,7 +145,12 @@
       </fieldset>
 
       <div class="response-section">
-        <label class="response-label" for="response-input">{{yourResponse}}</label>
+        <div class="response-header">
+          <label class="response-label" for="response-input">{{yourResponse}}</label>
+          <button type="button" id="attach-btn" class="attach-btn" title="{{addAttachment}}" aria-label="{{addAttachment}}">
+            <span class="codicon codicon-attach"></span>
+          </button>
+        </div>
 
         <!-- Autocomplete dropdown - positioned above input container -->
         <div id="autocomplete-dropdown" class="autocomplete-dropdown hidden">
@@ -169,13 +174,8 @@
           <!-- Chips bar (hidden when no attachments) -->
           <div id="chips-container" class="chips-container hidden"></div>
 
-          <!-- Input area with attach button and textarea -->
+          <!-- Input area with textarea only -->
           <div class="input-area">
-            <!-- Attach button on the left -->
-            <button type="button" id="attach-btn" class="attach-btn" title="{{addAttachment}}">
-              <span class="codicon codicon-attach"></span>
-            </button>
-
             <!-- Textarea wrapper -->
             <div class="textarea-wrapper">
               <textarea id="response-input" placeholder="{{inputPlaceholder}}" rows="1"></textarea>

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -2057,9 +2057,8 @@ function applyAskUserOptionsTooltipMode(): void {
                                 );
                             }
                             const att = rawAtt as AttachmentInfo;
-                            const isImage = att.isImage || /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(att.name);
+                            const isImage = isPreviewableImageAttachment(att);
                             const isFolder = att.isFolder;
-                            const hasThumbnailOrUri = !!(att.thumbnail || att.uri);
 
                             let iconClass: string;
                             let displayName: string;
@@ -2086,18 +2085,20 @@ function applyAskUserOptionsTooltipMode(): void {
 
                             let chip: HTMLElement;
 
-                            if (isImage && hasThumbnailOrUri && hoverPreview && hoverPreviewImg) {
+                            if (isImage && hoverPreview && hoverPreviewImg) {
                                 chipOptions.on = {
                                     mouseenter: () => {
-                                        const src = att.thumbnail || att.uri;
-                                        hoverPreviewImg.setAttribute('src', src);
-                                        hoverPreviewImg.setAttribute('alt', att.name);
                                         const rect = chip.getBoundingClientRect();
-                                        hoverPreview.style.top = `${rect.top - hoverPreview.offsetHeight - 8}px`;
-                                        hoverPreview.classList.remove('hidden');
+                                        showImageHoverPreview(
+                                            hoverPreview,
+                                            hoverPreviewImg,
+                                            att.thumbnail || att.uri,
+                                            att.name,
+                                            rect.top - hoverPreview.offsetHeight - 8
+                                        );
                                     },
                                     mouseleave: () => {
-                                        hoverPreview.classList.add('hidden');
+                                        hideImageHoverPreview(hoverPreview);
                                     }
                                 };
                             }
@@ -2174,6 +2175,23 @@ function applyAskUserOptionsTooltipMode(): void {
         updateChipsDisplay();
     }
 
+    function isPreviewableImageAttachment(att: AttachmentInfo): boolean {
+        const isImage = att.isImage || /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(att.name);
+        return isImage && !!(att.thumbnail || att.uri);
+    }
+
+    function showImageHoverPreview(preview: HTMLElement | null, previewImg: HTMLImageElement | null, src: string, alt: string, top: number): void {
+        if (!preview || !previewImg) return;
+        previewImg.setAttribute('src', src);
+        previewImg.setAttribute('alt', alt);
+        preview.style.top = `${top}px`;
+        preview.classList.remove('hidden');
+    }
+
+    function hideImageHoverPreview(preview: HTMLElement | null): void {
+        preview?.classList.add('hidden');
+    }
+
     /**
     * Update chips display above textarea
     */
@@ -2192,9 +2210,9 @@ function applyAskUserOptionsTooltipMode(): void {
             const preview = document.querySelector('.image-hover-preview') as HTMLElement;
             const previewImg = preview?.querySelector('img') as HTMLImageElement;
 
-            preview.classList.add('hidden');
+            hideImageHoverPreview(preview);
             chipsContainer.replaceChildren(...currentAttachments.map(att => {
-                const isImage = att.isImage || /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(att.name);
+                const isImage = isPreviewableImageAttachment(att);
                 const isFolder = att.isFolder;
 
                 // Determine display name and icon
@@ -2227,21 +2245,17 @@ function applyAskUserOptionsTooltipMode(): void {
                         className: chipClass,
                         title: att.folderPath || att.uri || att.name,
                         attrs: { 'data-id': att.id },
-                        on: {
+                        on: isImage && preview && previewImg ? {
                             'mouseenter': async () => {
-                                previewImg.setAttribute('src', att?.thumbnail || att.uri);
-                                previewImg.setAttribute('alt', att.name);
-
                                 const rect = element.getBoundingClientRect();
                                 const previewRect = preview.getBoundingClientRect();
-                                const top = rect.top - previewRect.height - 8
-                                preview.style.top = `${top}px`;
-                                preview.classList.remove('hidden');
+                                const top = rect.top - previewRect.height - 8;
+                                showImageHoverPreview(preview, previewImg, att.thumbnail || att.uri, att.name, top);
                             },
                             'mouseleave': () => {
-                                preview.classList.add('hidden');
+                                hideImageHoverPreview(preview);
                             }
-                        }
+                        } : undefined
                     },
                     el('span', { className: 'chip-icon' },
                         el('span', { className: `codicon codicon-${iconClass}` })
@@ -2257,7 +2271,7 @@ function applyAskUserOptionsTooltipMode(): void {
                                 'click': (e) => {
                                     e.stopPropagation();
                                     removeAttachment(att.id);
-                                    preview.classList.add('hidden');
+                                    hideImageHoverPreview(preview);
                                 }
                             }
                         },


### PR DESCRIPTION
## Summary

Improves attachment UX in the `Your response` area:

* Moves the add-attachment action out of the textarea gutter into the response header, because its previous placement sat too close to typed content and made accidental clicks easy
* Keeps the attachment trigger at a fixed position instead of letting it stretch with textarea height
* Restricts hover previews to image attachments and removes the stale preview artifact on mouse leave

## Cause

* The attachment button lived inside the same flex row as the textarea, stayed visually flush with user input, and was easy to misclick while interacting with the response field
* Because the button was coupled to the textarea row, its position also shifted as the textarea grew
* Attachment chips attempted to drive the image preview overlay for non-image attachments
* The preview image source could be cleared while the overlay was still fading out, leaving a transient broken-image artifact

## Fix

* Move the attachment button into a dedicated response header next to `Your response`
* Adjust the textarea spacing and button styling so the input remains stable after removing the inline button
* Centralize previewability checks with `isPreviewableImageAttachment()`
* Only attach hover preview handlers for previewable image attachments
* Hide the preview overlay without clearing the image source during fade-out

## Screenshots

| Before1 | Before2 | After |
| --- | --- | --- | 
|<img width="363" height="236" alt="before 1" src="https://github.com/user-attachments/assets/12eb03f4-592f-45f6-b7ad-a23e5bbbc9a5" />|<img width="348" height="231" alt="befoer 2" src="https://github.com/user-attachments/assets/aa598e4b-e54a-4c01-8005-709a405da856" />|<img width="364" height="227" alt="after 3" src="https://github.com/user-attachments/assets/dbcaa727-ec81-475c-8028-ea95b5fcac6d" />| 

## Verification

* Ran `npm test -- --runInBand`
* Ran `npm run compile`
* Manually verified the attachment button stays separated from the textarea content, is less prone to accidental clicks, and no longer moves with textarea height
* Manually verified image attachments still preview on hover, non-image attachments do not, and hover out no longer leaves a residual image artifact