### PR TITLE
fix: oversized ask_user textarea when Seamless Agent panel is inactive

### DIFF
--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -1111,7 +1111,7 @@ function applyAskUserOptionsTooltipMode(): void {
         requestForm?.classList.remove('hidden');
 
         // Resize after the form becomes visible so placeholder wrapping affects scrollHeight correctly.
-        requestAnimationFrame(() => autoResizeTextarea());
+        scheduleQuestionLayoutRefresh();
 
         // Update attachments display
         updateAttachmentsDisplay();
@@ -1121,6 +1121,14 @@ function applyAskUserOptionsTooltipMode(): void {
         if (document.hasFocus()) {
             responseInput?.focus();
         }
+    }
+
+    function scheduleQuestionLayoutRefresh(): void {
+        if (!responseInput || requestForm?.classList.contains('hidden')) {
+            return;
+        }
+
+        requestAnimationFrame(() => autoResizeTextarea());
     }
 
     /**
@@ -3415,6 +3423,9 @@ function applyAskUserOptionsTooltipMode(): void {
                 switchTab(message.tab);
             }
 
+                break;
+            case 'refreshLayout':
+                scheduleQuestionLayoutRefresh();
                 break;
             case 'batchDeleteCompleted':
                 // Exit batch mode after delete operation (whether confirmed or cancelled)

--- a/src/webview/types.ts
+++ b/src/webview/types.ts
@@ -166,6 +166,9 @@ export type ToWebviewMessage = | {
         value: boolean | string | number;
     }
     | {
+        type: 'refreshLayout'
+    }
+    | {
         type: 'clear'
     };
 

--- a/src/webview/webviewProvider.ts
+++ b/src/webview/webviewProvider.ts
@@ -128,6 +128,9 @@ export class AgentInteractionProvider implements vscode.WebviewViewProvider {
         webviewView.onDidChangeVisibility(() => {
             if (webviewView.visible) {
                 this._hasShownHiddenPendingNotification = false;
+                webviewView.webview.postMessage({
+                    type: 'refreshLayout'
+                } as ToWebviewMessage);
             }
         }, undefined, []);
 


### PR DESCRIPTION
## Problem
After b0e21af (`fix: textarea sizing in narrow sidebar`), a pending `ask_user` request can occasionally show an oversized response textarea when the Seamless Agent panel is not the active view. Once the user types a few characters, the height is recalculated and returns to normal.

## Cause
The textarea height is computed from `scrollHeight`, and empty requests rely on the placeholder for the initial measurement. The request form now resizes after it becomes visible so placeholder wrapping is measured correctly in narrow sidebars.

However, if a pending request is rendered while the Seamless Agent panel is not active, the webview can still receive and render the request before the layout is fully visible. In that state, the empty textarea may be measured against an unstable placeholder layout, causing `scrollHeight` to be larger than expected. Typing into the field triggers another resize, which is why the issue corrects itself after input.

## Fix
Refresh the request layout when the Seamless Agent panel becomes visible again. This forces the textarea to resize once more after the panel is active, so the final height is measured against the stable visible layout.

## Screenshots

| Before | After |
| --- | --- | 
|<img width="357" height="329" alt="image" src="https://github.com/user-attachments/assets/a653b2f7-2c34-4267-a5a2-0d7e6b43ae6f" />|<img width="346" height="161" alt="image" src="https://github.com/user-attachments/assets/d9776516-fec4-48f8-8a1f-791c105a32c4" />|


## Testing
- `npm run check-types`
- reproduced the issue locally with the Seamless Agent panel inactive
- verified the textarea height is recalculated when the panel becomes visible